### PR TITLE
Use custom argument parsers for the test args/run settings

### DIFF
--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -118,7 +118,7 @@ namespace Microsoft.DotNet.Cli
             //           all of the parameters of their wrapped command by design)
             //           error. so `dotnet msbuild /t:thing` throws a parse error.
             // .UseParseErrorReporting(127)
-            .UseParseErrorReporting("new")
+            .UseParseErrorReporting("new", "test")
             .UseHelp()
             .UseHelpBuilder(context => DotnetHelpBuilder.Instance.Value)
             .UseLocalizationResources(new CommandLineValidationMessages())
@@ -127,12 +127,12 @@ namespace Microsoft.DotNet.Cli
             .DisablePosixBinding()
             .Build();
 
-        private static CommandLineBuilder UseParseErrorReporting(this CommandLineBuilder builder, string commandName)
+        private static CommandLineBuilder UseParseErrorReporting(this CommandLineBuilder builder, params string[] commandName)
         {
             builder.AddMiddleware(async (context, next) =>
             {
                 CommandResult currentCommandResult = context.ParseResult.CommandResult;
-                while (currentCommandResult != null && currentCommandResult.Command.Name != commandName)
+                while (currentCommandResult != null && !(commandName.Contains(currentCommandResult.Command.Name)))
                 {
                     currentCommandResult = currentCommandResult.Parent as CommandResult;
                 }

--- a/src/Cli/dotnet/commands/dotnet-test/LocalizableStrings.resx
+++ b/src/Cli/dotnet/commands/dotnet-test/LocalizableStrings.resx
@@ -123,6 +123,21 @@
   <data name="AppDescription" xml:space="preserve">
     <value>Test Driver for the .NET Platform</value>
   </data>
+  <data name="AdditionalArguments" xml:space="preserve">
+    <value>forwarded arguments</value>
+  </data>
+  <data name="AdditionalArgumentsDescription" xml:space="preserve">
+    <value>Specifies extra arguments to pass to the adapter. Use a space to separate multiple arguments. If the item being tested is a project, solution, or directory this argument will be passed to MSBuild. If the item being tested is a .dll or an .exe this argument will be passed to vstest.</value>
+  </data>
+  <data name="CouldNotParseRunSetting" xml:space="preserve">
+    <value>Argument '{0}' could not be parsed as a RunSetting. Use a key/value pair separated with an equals character, like 'foo=bar'</value>
+  </data>
+  <data name="RunSettings" xml:space="preserve">
+    <value>run settings</value>
+  </data>
+  <data name="RunSettingsDescription" xml:space="preserve">
+    <value>KEY=VALUE pairs that replace or augment RunSettings values from any specified .runsettings files </value>
+  </data>
   <data name="CmdSettingsFile" xml:space="preserve">
     <value>SETTINGS_FILE</value>
   </data>

--- a/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
@@ -129,7 +129,7 @@ namespace Microsoft.DotNet.Cli
                     // TODO(ch): Localizable name for this
                     ctx.ErrorMessage = $"Argument '{token.Value}' could not be parsed as a RunSetting. Use a key/value pair separated with an equals character, like 'foo=bar'";
                     ctx.OnlyTake(consumed);
-                    return Array.Empty<(string key, string value)>();
+                    return null;
                 }
             }
             ctx.OnlyTake(consumed);

--- a/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
+++ b/src/Cli/dotnet/commands/dotnet-test/TestCommandParser.cs
@@ -105,8 +105,7 @@ namespace Microsoft.DotNet.Cli
             return tokens.ToArray();
         };
 
-        // TODO(ch): localizable names and descriptions for this
-        public static readonly Argument<string[]> ForwardedArgs = new("adapter-args", parse: ParseUntilFirstPotentialRunSetting)
+        public static readonly Argument<string[]> ForwardedArgs = new(LocalizableStrings.AdditionalArguments, parse: ParseUntilFirstPotentialRunSetting, description: LocalizableStrings.AdditionalArgumentsDescription)
         {
             Arity = ArgumentArity.ZeroOrMore
         };
@@ -130,8 +129,8 @@ namespace Microsoft.DotNet.Cli
                 }
                 else
                 {
-                    // TODO(ch): Localizable name for this
-                    ctx.ErrorMessage = $"Argument '{token.Value}' could not be parsed as a RunSetting. Use a key/value pair separated with an equals character, like 'foo=bar'";
+                    //$"Argument '{token.Value}' could not be parsed as a RunSetting. Use a key/value pair separated with an equals character, like 'foo=bar'";
+                    ctx.ErrorMessage = String.Format(LocalizableStrings.CouldNotParseRunSetting, token.Value);
                     ctx.OnlyTake(consumed);
                     return null;
                 }
@@ -140,8 +139,7 @@ namespace Microsoft.DotNet.Cli
             return settings.ToArray();
         };
 
-        // TODO(ch): localizable names and descriptions for this
-        public static readonly Argument<(string key, string value)[]> InlineRunSettings = new("inline-run-settings", parse: ParseRunSettings)
+        public static readonly Argument<(string key, string value)[]> InlineRunSettings = new(LocalizableStrings.RunSettings, parse: ParseRunSettings, description: LocalizableStrings.RunSettingsDescription)
         {
             Arity = ArgumentArity.ZeroOrMore
         };

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="AdditionalArguments">
+        <source>forwarded arguments</source>
+        <target state="new">forwarded arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AdditionalArgumentsDescription">
+        <source>Specifies extra arguments to pass to the adapter. Use a space to separate multiple arguments. If the item being tested is a project, solution, or directory this argument will be passed to MSBuild. If the item being tested is a .dll or an .exe this argument will be passed to vstest.</source>
+        <target state="new">Specifies extra arguments to pass to the adapter. Use a space to separate multiple arguments. If the item being tested is a project, solution, or directory this argument will be passed to MSBuild. If the item being tested is a .dll or an .exe this argument will be passed to vstest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppFullName">
         <source>.NET Test Driver</source>
         <target state="translated">Testovací ovladač .NET</target>
@@ -195,6 +205,11 @@ Pokud zadaný adresář neexistuje, bude vytvořen.</target>
         <target state="translated">RESULTS_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotParseRunSetting">
+        <source>Argument '{0}' could not be parsed as a RunSetting. Use a key/value pair separated with an equals character, like 'foo=bar'</source>
+        <target state="new">Argument '{0}' could not be parsed as a RunSetting. Use a key/value pair separated with an equals character, like 'foo=bar'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CrashDumpTypeArgumentName">
         <source>DUMP_TYPE</source>
         <target state="translated">DUMP_TYPE</target>
@@ -215,6 +230,11 @@ Pokud zadaný adresář neexistuje, bude vytvořen.</target>
         <target state="translated">Následující argumenty se ignorovaly: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunSettings">
+        <source>run settings</source>
+        <target state="new">run settings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunSettingsArgumentsDescription">
         <source>
 
@@ -230,6 +250,11 @@ Argumenty RunSettings:
  K oddělení více dvojic [název]=[hodnota] použijte mezeru.
  Další informace o argumentech RunSettings: https://aka.ms/vstest-runsettings-arguments.
  Příklad: dotnet test -- MSTest.DeploymentEnabled=false MSTest.MapInconclusiveToFailed=True</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunSettingsDescription">
+        <source>KEY=VALUE pairs that replace or augment RunSettings values from any specified .runsettings files </source>
+        <target state="new">KEY=VALUE pairs that replace or augment RunSettings values from any specified .runsettings files </target>
         <note />
       </trans-unit>
       <trans-unit id="cmdCollectFriendlyName">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="AdditionalArguments">
+        <source>forwarded arguments</source>
+        <target state="new">forwarded arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AdditionalArgumentsDescription">
+        <source>Specifies extra arguments to pass to the adapter. Use a space to separate multiple arguments. If the item being tested is a project, solution, or directory this argument will be passed to MSBuild. If the item being tested is a .dll or an .exe this argument will be passed to vstest.</source>
+        <target state="new">Specifies extra arguments to pass to the adapter. Use a space to separate multiple arguments. If the item being tested is a project, solution, or directory this argument will be passed to MSBuild. If the item being tested is a .dll or an .exe this argument will be passed to vstest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppFullName">
         <source>.NET Test Driver</source>
         <target state="translated">.NET-Testtreiber</target>
@@ -195,6 +205,11 @@ Das angegebene Verzeichnis wird erstellt, wenn es nicht vorhanden ist.</target>
         <target state="translated">RESULTS_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotParseRunSetting">
+        <source>Argument '{0}' could not be parsed as a RunSetting. Use a key/value pair separated with an equals character, like 'foo=bar'</source>
+        <target state="new">Argument '{0}' could not be parsed as a RunSetting. Use a key/value pair separated with an equals character, like 'foo=bar'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CrashDumpTypeArgumentName">
         <source>DUMP_TYPE</source>
         <target state="translated">DUMP_TYPE</target>
@@ -215,6 +230,11 @@ Das angegebene Verzeichnis wird erstellt, wenn es nicht vorhanden ist.</target>
         <target state="translated">Die folgenden Argumente wurden ignoriert: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunSettings">
+        <source>run settings</source>
+        <target state="new">run settings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunSettingsArgumentsDescription">
         <source>
 
@@ -230,6 +250,11 @@ RunSettings-Argumente:
       Trennen Sie mehrere Paare der Form "[Name]=[Wert]" mithilfe von Leerzeichen.
       Weitere Informationen zu RunSettings-Argumenten finden Sie unter https://aka.ms/vstest-runsettings-arguments.
   Beispiel: "dotnet test -- MSTest.DeploymentEnabled=false MSTest.MapInconclusiveToFailed=True"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunSettingsDescription">
+        <source>KEY=VALUE pairs that replace or augment RunSettings values from any specified .runsettings files </source>
+        <target state="new">KEY=VALUE pairs that replace or augment RunSettings values from any specified .runsettings files </target>
         <note />
       </trans-unit>
       <trans-unit id="cmdCollectFriendlyName">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="AdditionalArguments">
+        <source>forwarded arguments</source>
+        <target state="new">forwarded arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AdditionalArgumentsDescription">
+        <source>Specifies extra arguments to pass to the adapter. Use a space to separate multiple arguments. If the item being tested is a project, solution, or directory this argument will be passed to MSBuild. If the item being tested is a .dll or an .exe this argument will be passed to vstest.</source>
+        <target state="new">Specifies extra arguments to pass to the adapter. Use a space to separate multiple arguments. If the item being tested is a project, solution, or directory this argument will be passed to MSBuild. If the item being tested is a .dll or an .exe this argument will be passed to vstest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppFullName">
         <source>.NET Test Driver</source>
         <target state="translated">Controlador de pruebas de .NET</target>
@@ -195,6 +205,11 @@ Si no existe, se creará el directorio especificado.</target>
         <target state="translated">RESULTS_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotParseRunSetting">
+        <source>Argument '{0}' could not be parsed as a RunSetting. Use a key/value pair separated with an equals character, like 'foo=bar'</source>
+        <target state="new">Argument '{0}' could not be parsed as a RunSetting. Use a key/value pair separated with an equals character, like 'foo=bar'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CrashDumpTypeArgumentName">
         <source>DUMP_TYPE</source>
         <target state="translated">DUMP_TYPE</target>
@@ -215,6 +230,11 @@ Si no existe, se creará el directorio especificado.</target>
         <target state="translated">Se han omitido los argumentos siguientes: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunSettings">
+        <source>run settings</source>
+        <target state="new">run settings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunSettingsArgumentsDescription">
         <source>
 
@@ -230,6 +250,11 @@ Argumentos RunSettings:
   Use un espacio para separar varios pares de "[nombre] =[valor]".
   Consulte https://aka.ms/vstest-runsettings-arguments para obtener información sobre los argumentos RunSettings:
   Ejemplo: dotnet test -- MSTest.DeploymentEnabled=false MSTest.MapInconclusiveToFailed=True</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunSettingsDescription">
+        <source>KEY=VALUE pairs that replace or augment RunSettings values from any specified .runsettings files </source>
+        <target state="new">KEY=VALUE pairs that replace or augment RunSettings values from any specified .runsettings files </target>
         <note />
       </trans-unit>
       <trans-unit id="cmdCollectFriendlyName">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="AdditionalArguments">
+        <source>forwarded arguments</source>
+        <target state="new">forwarded arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AdditionalArgumentsDescription">
+        <source>Specifies extra arguments to pass to the adapter. Use a space to separate multiple arguments. If the item being tested is a project, solution, or directory this argument will be passed to MSBuild. If the item being tested is a .dll or an .exe this argument will be passed to vstest.</source>
+        <target state="new">Specifies extra arguments to pass to the adapter. Use a space to separate multiple arguments. If the item being tested is a project, solution, or directory this argument will be passed to MSBuild. If the item being tested is a .dll or an .exe this argument will be passed to vstest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppFullName">
         <source>.NET Test Driver</source>
         <target state="translated">Pilote de test .NET</target>
@@ -195,6 +205,11 @@ Le répertoire spécifié est créé, s'il n'existe pas déjà.</target>
         <target state="translated">RESULTS_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotParseRunSetting">
+        <source>Argument '{0}' could not be parsed as a RunSetting. Use a key/value pair separated with an equals character, like 'foo=bar'</source>
+        <target state="new">Argument '{0}' could not be parsed as a RunSetting. Use a key/value pair separated with an equals character, like 'foo=bar'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CrashDumpTypeArgumentName">
         <source>DUMP_TYPE</source>
         <target state="translated">DUMP_TYPE</target>
@@ -215,6 +230,11 @@ Le répertoire spécifié est créé, s'il n'existe pas déjà.</target>
         <target state="translated">Les arguments suivants ont été ignorés : "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunSettings">
+        <source>run settings</source>
+        <target state="new">run settings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunSettingsArgumentsDescription">
         <source>
 
@@ -230,6 +250,11 @@ Arguments de RunSettings :
   Utilisez un espace pour séparer plusieurs paires '[name]=[value]'.
   Pour plus d'informations sur les arguments de RunSettings, consultez https://aka.ms/vstest-runsettings-arguments.
   Exemple : dotnet test -- MSTest.DeploymentEnabled=false MSTest.MapInconclusiveToFailed=True</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunSettingsDescription">
+        <source>KEY=VALUE pairs that replace or augment RunSettings values from any specified .runsettings files </source>
+        <target state="new">KEY=VALUE pairs that replace or augment RunSettings values from any specified .runsettings files </target>
         <note />
       </trans-unit>
       <trans-unit id="cmdCollectFriendlyName">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="AdditionalArguments">
+        <source>forwarded arguments</source>
+        <target state="new">forwarded arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AdditionalArgumentsDescription">
+        <source>Specifies extra arguments to pass to the adapter. Use a space to separate multiple arguments. If the item being tested is a project, solution, or directory this argument will be passed to MSBuild. If the item being tested is a .dll or an .exe this argument will be passed to vstest.</source>
+        <target state="new">Specifies extra arguments to pass to the adapter. Use a space to separate multiple arguments. If the item being tested is a project, solution, or directory this argument will be passed to MSBuild. If the item being tested is a .dll or an .exe this argument will be passed to vstest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppFullName">
         <source>.NET Test Driver</source>
         <target state="translated">Driver di test .NET</target>
@@ -195,6 +205,11 @@ Se non esiste, la directory specificata verrà creata.</target>
         <target state="translated">RESULTS_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotParseRunSetting">
+        <source>Argument '{0}' could not be parsed as a RunSetting. Use a key/value pair separated with an equals character, like 'foo=bar'</source>
+        <target state="new">Argument '{0}' could not be parsed as a RunSetting. Use a key/value pair separated with an equals character, like 'foo=bar'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CrashDumpTypeArgumentName">
         <source>DUMP_TYPE</source>
         <target state="translated">DUMP_TYPE</target>
@@ -215,6 +230,11 @@ Se non esiste, la directory specificata verrà creata.</target>
         <target state="translated">Gli argomenti seguenti sono stati ignorati: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunSettings">
+        <source>run settings</source>
+        <target state="new">run settings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunSettingsArgumentsDescription">
         <source>
 
@@ -230,6 +250,11 @@ Argomenti di RunSettings:
   Usare uno spazio per separare più coppie '[nome]=[valore]'.
   Per altre informazioni sugli argomenti di RunSettings, vedere: https://aka.ms/vstest-runsettings-arguments
   Esempio: dotnet test -- MSTest.DeploymentEnabled=false MSTest.MapInconclusiveToFailed=True</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunSettingsDescription">
+        <source>KEY=VALUE pairs that replace or augment RunSettings values from any specified .runsettings files </source>
+        <target state="new">KEY=VALUE pairs that replace or augment RunSettings values from any specified .runsettings files </target>
         <note />
       </trans-unit>
       <trans-unit id="cmdCollectFriendlyName">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="AdditionalArguments">
+        <source>forwarded arguments</source>
+        <target state="new">forwarded arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AdditionalArgumentsDescription">
+        <source>Specifies extra arguments to pass to the adapter. Use a space to separate multiple arguments. If the item being tested is a project, solution, or directory this argument will be passed to MSBuild. If the item being tested is a .dll or an .exe this argument will be passed to vstest.</source>
+        <target state="new">Specifies extra arguments to pass to the adapter. Use a space to separate multiple arguments. If the item being tested is a project, solution, or directory this argument will be passed to MSBuild. If the item being tested is a .dll or an .exe this argument will be passed to vstest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppFullName">
         <source>.NET Test Driver</source>
         <target state="translated">.NET Test Driver</target>
@@ -195,6 +205,11 @@ The specified directory will be created if it does not exist.</source>
         <target state="translated">RESULTS_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotParseRunSetting">
+        <source>Argument '{0}' could not be parsed as a RunSetting. Use a key/value pair separated with an equals character, like 'foo=bar'</source>
+        <target state="new">Argument '{0}' could not be parsed as a RunSetting. Use a key/value pair separated with an equals character, like 'foo=bar'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CrashDumpTypeArgumentName">
         <source>DUMP_TYPE</source>
         <target state="translated">DUMP_TYPE</target>
@@ -215,6 +230,11 @@ The specified directory will be created if it does not exist.</source>
         <target state="translated">次の引数は無視されました: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunSettings">
+        <source>run settings</source>
+        <target state="new">run settings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunSettingsArgumentsDescription">
         <source>
 
@@ -230,6 +250,11 @@ RunSettings 引数:
   複数の [name] =[value] ペアを区切るにはスペースを使用します。
   RunSettings 引数関する詳細は、https://aka.ms/vstest-runsettings-arguments をご覧ください。
   例: dotnet test -- MSTest.DeploymentEnabled=false MSTest.MapInconclusiveToFailed=True</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunSettingsDescription">
+        <source>KEY=VALUE pairs that replace or augment RunSettings values from any specified .runsettings files </source>
+        <target state="new">KEY=VALUE pairs that replace or augment RunSettings values from any specified .runsettings files </target>
         <note />
       </trans-unit>
       <trans-unit id="cmdCollectFriendlyName">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="AdditionalArguments">
+        <source>forwarded arguments</source>
+        <target state="new">forwarded arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AdditionalArgumentsDescription">
+        <source>Specifies extra arguments to pass to the adapter. Use a space to separate multiple arguments. If the item being tested is a project, solution, or directory this argument will be passed to MSBuild. If the item being tested is a .dll or an .exe this argument will be passed to vstest.</source>
+        <target state="new">Specifies extra arguments to pass to the adapter. Use a space to separate multiple arguments. If the item being tested is a project, solution, or directory this argument will be passed to MSBuild. If the item being tested is a .dll or an .exe this argument will be passed to vstest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppFullName">
         <source>.NET Test Driver</source>
         <target state="translated">.NET 테스트 드라이버</target>
@@ -195,6 +205,11 @@ The specified directory will be created if it does not exist.</source>
         <target state="translated">RESULTS_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotParseRunSetting">
+        <source>Argument '{0}' could not be parsed as a RunSetting. Use a key/value pair separated with an equals character, like 'foo=bar'</source>
+        <target state="new">Argument '{0}' could not be parsed as a RunSetting. Use a key/value pair separated with an equals character, like 'foo=bar'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CrashDumpTypeArgumentName">
         <source>DUMP_TYPE</source>
         <target state="translated">DUMP_TYPE</target>
@@ -215,6 +230,11 @@ The specified directory will be created if it does not exist.</source>
         <target state="translated">"{0}" 인수가 무시되었습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunSettings">
+        <source>run settings</source>
+        <target state="new">run settings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunSettingsArgumentsDescription">
         <source>
 
@@ -230,6 +250,11 @@ RunSettings 인수:
   여러 '[name] =[value]' 쌍을 구분하려면 공백을 사용합니다.
   RunSettings 인수에 대한 자세한 내용은 https://aka.ms/vstest-runsettings-arguments를 참조하세요.
   예: dotnet test -- MSTest.DeploymentEnabled=false MSTest.MapInconclusiveToFailed=True</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunSettingsDescription">
+        <source>KEY=VALUE pairs that replace or augment RunSettings values from any specified .runsettings files </source>
+        <target state="new">KEY=VALUE pairs that replace or augment RunSettings values from any specified .runsettings files </target>
         <note />
       </trans-unit>
       <trans-unit id="cmdCollectFriendlyName">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="AdditionalArguments">
+        <source>forwarded arguments</source>
+        <target state="new">forwarded arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AdditionalArgumentsDescription">
+        <source>Specifies extra arguments to pass to the adapter. Use a space to separate multiple arguments. If the item being tested is a project, solution, or directory this argument will be passed to MSBuild. If the item being tested is a .dll or an .exe this argument will be passed to vstest.</source>
+        <target state="new">Specifies extra arguments to pass to the adapter. Use a space to separate multiple arguments. If the item being tested is a project, solution, or directory this argument will be passed to MSBuild. If the item being tested is a .dll or an .exe this argument will be passed to vstest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppFullName">
         <source>.NET Test Driver</source>
         <target state="translated">Sterownik testów platformy .NET</target>
@@ -195,6 +205,11 @@ Jeśli określony katalog nie istnieje, zostanie utworzony.</target>
         <target state="translated">RESULTS_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotParseRunSetting">
+        <source>Argument '{0}' could not be parsed as a RunSetting. Use a key/value pair separated with an equals character, like 'foo=bar'</source>
+        <target state="new">Argument '{0}' could not be parsed as a RunSetting. Use a key/value pair separated with an equals character, like 'foo=bar'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CrashDumpTypeArgumentName">
         <source>DUMP_TYPE</source>
         <target state="translated">DUMP_TYPE</target>
@@ -215,6 +230,11 @@ Jeśli określony katalog nie istnieje, zostanie utworzony.</target>
         <target state="translated">Następujące argumenty zostały zignorowane: „{0}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunSettings">
+        <source>run settings</source>
+        <target state="new">run settings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunSettingsArgumentsDescription">
         <source>
 
@@ -230,6 +250,11 @@ Argumenty RunSettings:
   Oddziel wiele par „[nazwa]=[wartość]” za pomocą spacji.
   Aby uzyskać więcej informacji na temat obsługi argumentów RunSettings, zobacz https://aka.ms/vstest-runsettings-arguments.
   Przykład: dotnet test -- MSTest.DeploymentEnabled=false MSTest.MapInconclusiveToFailed=True</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunSettingsDescription">
+        <source>KEY=VALUE pairs that replace or augment RunSettings values from any specified .runsettings files </source>
+        <target state="new">KEY=VALUE pairs that replace or augment RunSettings values from any specified .runsettings files </target>
         <note />
       </trans-unit>
       <trans-unit id="cmdCollectFriendlyName">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="AdditionalArguments">
+        <source>forwarded arguments</source>
+        <target state="new">forwarded arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AdditionalArgumentsDescription">
+        <source>Specifies extra arguments to pass to the adapter. Use a space to separate multiple arguments. If the item being tested is a project, solution, or directory this argument will be passed to MSBuild. If the item being tested is a .dll or an .exe this argument will be passed to vstest.</source>
+        <target state="new">Specifies extra arguments to pass to the adapter. Use a space to separate multiple arguments. If the item being tested is a project, solution, or directory this argument will be passed to MSBuild. If the item being tested is a .dll or an .exe this argument will be passed to vstest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppFullName">
         <source>.NET Test Driver</source>
         <target state="translated">Driver de Teste do .NET</target>
@@ -195,6 +205,11 @@ O diretório especificado será criado se ele ainda não existir.</target>
         <target state="translated">RESULTS_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotParseRunSetting">
+        <source>Argument '{0}' could not be parsed as a RunSetting. Use a key/value pair separated with an equals character, like 'foo=bar'</source>
+        <target state="new">Argument '{0}' could not be parsed as a RunSetting. Use a key/value pair separated with an equals character, like 'foo=bar'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CrashDumpTypeArgumentName">
         <source>DUMP_TYPE</source>
         <target state="translated">DUMP_TYPE</target>
@@ -215,6 +230,11 @@ O diretório especificado será criado se ele ainda não existir.</target>
         <target state="translated">Os argumentos a seguir foram ignorados: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunSettings">
+        <source>run settings</source>
+        <target state="new">run settings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunSettingsArgumentsDescription">
         <source>
 
@@ -230,6 +250,11 @@ Argumentos de RunSettings:
   Use um espaço para separar vários pares '[name]=[value]'.
   Confira https://aka.ms/vstest-runsettings-arguments para obter mais informações sobre os argumentos de RunSettings.
   Exemplo: dotnet test -- MSTest.DeploymentEnabled=false MSTest.MapInconclusiveToFailed=True</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunSettingsDescription">
+        <source>KEY=VALUE pairs that replace or augment RunSettings values from any specified .runsettings files </source>
+        <target state="new">KEY=VALUE pairs that replace or augment RunSettings values from any specified .runsettings files </target>
         <note />
       </trans-unit>
       <trans-unit id="cmdCollectFriendlyName">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="AdditionalArguments">
+        <source>forwarded arguments</source>
+        <target state="new">forwarded arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AdditionalArgumentsDescription">
+        <source>Specifies extra arguments to pass to the adapter. Use a space to separate multiple arguments. If the item being tested is a project, solution, or directory this argument will be passed to MSBuild. If the item being tested is a .dll or an .exe this argument will be passed to vstest.</source>
+        <target state="new">Specifies extra arguments to pass to the adapter. Use a space to separate multiple arguments. If the item being tested is a project, solution, or directory this argument will be passed to MSBuild. If the item being tested is a .dll or an .exe this argument will be passed to vstest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppFullName">
         <source>.NET Test Driver</source>
         <target state="translated">Драйвер тестов .NET</target>
@@ -195,6 +205,11 @@ The specified directory will be created if it does not exist.</source>
         <target state="translated">RESULTS_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotParseRunSetting">
+        <source>Argument '{0}' could not be parsed as a RunSetting. Use a key/value pair separated with an equals character, like 'foo=bar'</source>
+        <target state="new">Argument '{0}' could not be parsed as a RunSetting. Use a key/value pair separated with an equals character, like 'foo=bar'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CrashDumpTypeArgumentName">
         <source>DUMP_TYPE</source>
         <target state="translated">DUMP_TYPE</target>
@@ -215,6 +230,11 @@ The specified directory will be created if it does not exist.</source>
         <target state="translated">Следующие аргументы пропущены: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunSettings">
+        <source>run settings</source>
+        <target state="new">run settings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunSettingsArgumentsDescription">
         <source>
 
@@ -230,6 +250,11 @@ RunSettings arguments:
   Используйте пробел для разделения нескольких пар "[имя]=[значение]".
   Дополнительные сведения об аргументах RunSettings: https://aka.ms/vstest-runsettings-arguments.
   Пример: dotnet test -- MSTest.DeploymentEnabled=false MSTest.MapInconclusiveToFailed=True</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunSettingsDescription">
+        <source>KEY=VALUE pairs that replace or augment RunSettings values from any specified .runsettings files </source>
+        <target state="new">KEY=VALUE pairs that replace or augment RunSettings values from any specified .runsettings files </target>
         <note />
       </trans-unit>
       <trans-unit id="cmdCollectFriendlyName">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="AdditionalArguments">
+        <source>forwarded arguments</source>
+        <target state="new">forwarded arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AdditionalArgumentsDescription">
+        <source>Specifies extra arguments to pass to the adapter. Use a space to separate multiple arguments. If the item being tested is a project, solution, or directory this argument will be passed to MSBuild. If the item being tested is a .dll or an .exe this argument will be passed to vstest.</source>
+        <target state="new">Specifies extra arguments to pass to the adapter. Use a space to separate multiple arguments. If the item being tested is a project, solution, or directory this argument will be passed to MSBuild. If the item being tested is a .dll or an .exe this argument will be passed to vstest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppFullName">
         <source>.NET Test Driver</source>
         <target state="translated">.NET Test Sürücüsü</target>
@@ -195,6 +205,11 @@ Belirtilen dizin yoksa oluşturulur.</target>
         <target state="translated">RESULTS_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotParseRunSetting">
+        <source>Argument '{0}' could not be parsed as a RunSetting. Use a key/value pair separated with an equals character, like 'foo=bar'</source>
+        <target state="new">Argument '{0}' could not be parsed as a RunSetting. Use a key/value pair separated with an equals character, like 'foo=bar'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CrashDumpTypeArgumentName">
         <source>DUMP_TYPE</source>
         <target state="translated">DÖKÜM_TÜRÜ</target>
@@ -215,6 +230,11 @@ Belirtilen dizin yoksa oluşturulur.</target>
         <target state="translated">Şu bağımsız değişkenler yoksayıldı: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunSettings">
+        <source>run settings</source>
+        <target state="new">run settings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunSettingsArgumentsDescription">
         <source>
 
@@ -230,6 +250,11 @@ RunSettings bağımsız değişkenleri:
   Birden fazla '[ad]=[değer]' çiftini ayırmak için boşluk kullanın.
   RunSettings bağımsız değişkenleri hakkında daha fazla bilgi için bkz. https://aka.ms/vstest-runsettings-arguments.
   Örnek: dotnet test -- MSTest.DeploymentEnabled=false MSTest.MapInconclusiveToFailed=True</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunSettingsDescription">
+        <source>KEY=VALUE pairs that replace or augment RunSettings values from any specified .runsettings files </source>
+        <target state="new">KEY=VALUE pairs that replace or augment RunSettings values from any specified .runsettings files </target>
         <note />
       </trans-unit>
       <trans-unit id="cmdCollectFriendlyName">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="AdditionalArguments">
+        <source>forwarded arguments</source>
+        <target state="new">forwarded arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AdditionalArgumentsDescription">
+        <source>Specifies extra arguments to pass to the adapter. Use a space to separate multiple arguments. If the item being tested is a project, solution, or directory this argument will be passed to MSBuild. If the item being tested is a .dll or an .exe this argument will be passed to vstest.</source>
+        <target state="new">Specifies extra arguments to pass to the adapter. Use a space to separate multiple arguments. If the item being tested is a project, solution, or directory this argument will be passed to MSBuild. If the item being tested is a .dll or an .exe this argument will be passed to vstest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppFullName">
         <source>.NET Test Driver</source>
         <target state="translated">.NET 测试驱动程序</target>
@@ -195,6 +205,11 @@ The specified directory will be created if it does not exist.</source>
         <target state="translated">RESULTS_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotParseRunSetting">
+        <source>Argument '{0}' could not be parsed as a RunSetting. Use a key/value pair separated with an equals character, like 'foo=bar'</source>
+        <target state="new">Argument '{0}' could not be parsed as a RunSetting. Use a key/value pair separated with an equals character, like 'foo=bar'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CrashDumpTypeArgumentName">
         <source>DUMP_TYPE</source>
         <target state="translated">DUMP_TYPE</target>
@@ -215,6 +230,11 @@ The specified directory will be created if it does not exist.</source>
         <target state="translated">已忽略以下参数:“{0}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunSettings">
+        <source>run settings</source>
+        <target state="new">run settings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunSettingsArgumentsDescription">
         <source>
 
@@ -230,6 +250,11 @@ RunSettings 参数:
   使用空格分隔多个“[名称]=[值]”对。
   有关 RunSettings 参数的详细信息，请参阅 https://aka.ms/vstest-runsettings-arguments。
   示例: dotnet test -- MSTest.DeploymentEnabled=false MSTest.MapInconclusiveToFailed=True</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunSettingsDescription">
+        <source>KEY=VALUE pairs that replace or augment RunSettings values from any specified .runsettings files </source>
+        <target state="new">KEY=VALUE pairs that replace or augment RunSettings values from any specified .runsettings files </target>
         <note />
       </trans-unit>
       <trans-unit id="cmdCollectFriendlyName">

--- a/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="AdditionalArguments">
+        <source>forwarded arguments</source>
+        <target state="new">forwarded arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AdditionalArgumentsDescription">
+        <source>Specifies extra arguments to pass to the adapter. Use a space to separate multiple arguments. If the item being tested is a project, solution, or directory this argument will be passed to MSBuild. If the item being tested is a .dll or an .exe this argument will be passed to vstest.</source>
+        <target state="new">Specifies extra arguments to pass to the adapter. Use a space to separate multiple arguments. If the item being tested is a project, solution, or directory this argument will be passed to MSBuild. If the item being tested is a .dll or an .exe this argument will be passed to vstest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppFullName">
         <source>.NET Test Driver</source>
         <target state="translated">.NET 測試驅動程式</target>
@@ -195,6 +205,11 @@ The specified directory will be created if it does not exist.</source>
         <target state="translated">RESULTS_DIR</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotParseRunSetting">
+        <source>Argument '{0}' could not be parsed as a RunSetting. Use a key/value pair separated with an equals character, like 'foo=bar'</source>
+        <target state="new">Argument '{0}' could not be parsed as a RunSetting. Use a key/value pair separated with an equals character, like 'foo=bar'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CrashDumpTypeArgumentName">
         <source>DUMP_TYPE</source>
         <target state="translated">DUMP_TYPE</target>
@@ -215,6 +230,11 @@ The specified directory will be created if it does not exist.</source>
         <target state="translated">已忽略下列引數: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="RunSettings">
+        <source>run settings</source>
+        <target state="new">run settings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RunSettingsArgumentsDescription">
         <source>
 
@@ -230,6 +250,11 @@ RunSettings 引數:
   請使用空格隔開多個成對的 '[name]=[value]'。
   如需 RunSettings 引數的詳細資訊，請參閱 https://aka.ms/vstest-runsettings-arguments。
   範例: dotnet test -- MSTest.DeploymentEnabled=false MSTest.MapInconclusiveToFailed=True</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunSettingsDescription">
+        <source>KEY=VALUE pairs that replace or augment RunSettings values from any specified .runsettings files </source>
+        <target state="new">KEY=VALUE pairs that replace or augment RunSettings values from any specified .runsettings files </target>
         <note />
       </trans-unit>
       <trans-unit id="cmdCollectFriendlyName">


### PR DESCRIPTION
This builds on your changes to hopefully remove all of the `--`-aware logic from the CLI, replacing it with hopefully more user-friendly syntax while not harming backwards compatibility. The idea is that we push a lot of the argument parsing into custom ParseArgument delegates for the two arguments that we're attempting to parse - args to forward to the running application, and runsettings. If we have those captured at parse time, the execution-time logic gets _much_ simpler.